### PR TITLE
Use UML XMI Ids instead of random IDs and refactor GModelFactory code

### DIFF
--- a/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/gmodel/AbstractGModelFactory.java
+++ b/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/gmodel/AbstractGModelFactory.java
@@ -11,9 +11,9 @@
 package com.eclipsesource.uml.glsp.gmodel;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.glsp.graph.GModelElement;
 
 import com.eclipsesource.uml.glsp.model.UmlModelState;
@@ -35,7 +35,7 @@ public abstract class AbstractGModelFactory<T extends EObject, E extends GModelE
    protected String toId(final EObject semanticElement) {
       String id = modelState.getIndex().getSemanticId(semanticElement).orElse(null);
       if (id == null) {
-         id = UUID.randomUUID().toString();
+         id = EcoreUtil.getURI(semanticElement).fragment();
          modelState.getIndex().indexSemantic(id, semanticElement);
       }
       return id;

--- a/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/gmodel/GModelFactory.java
+++ b/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/gmodel/GModelFactory.java
@@ -28,14 +28,17 @@ public abstract class GModelFactory extends AbstractGModelFactory<EObject, GMode
 
    public GModelFactory(final UmlModelState modelState) {
       super(modelState);
-      classifierNodeFactory = new ClassifierNodeFactory(modelState, this);
       labelFactory = new LabelFactory(modelState);
       relationshipEdgeFactory = new RelationshipEdgeFactory(modelState);
+      classifierNodeFactory = new ClassifierNodeFactory(modelState, labelFactory);
       getOrCreateRoot();
    }
 
    @Override
-   public abstract GModelElement create(final EObject semanticElement);
+   public GModelElement create(final EObject semanticElement) {
+      // no-op as we focus on create(final Diagram umlDiagram)
+      return null;
+   }
 
    public abstract GGraph create(final Diagram umlDiagram);
 

--- a/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/gmodel/LabelFactory.java
+++ b/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/gmodel/LabelFactory.java
@@ -28,19 +28,19 @@ public class LabelFactory extends AbstractGModelFactory<NamedElement, GLabel> {
    @Override
    public GLabel create(final NamedElement namedElement) {
       if (namedElement instanceof Property) {
-         return create((Property) namedElement);
+         return createPropertyLabel((Property) namedElement);
       }
       return null;
    }
 
-   public GLabel create(final Property property) {
-      String label = property.getName()//
-         .concat(UmlLabelUtil.getTypeName(property))//
+   protected GLabel createPropertyLabel(final Property property) {
+      String label = property.getName()
+         .concat(UmlLabelUtil.getTypeName(property))
          .concat(UmlLabelUtil.getMultiplicity(property));
 
-      return new GLabelBuilder(Types.PROPERTY) //
-         .id(toId(property))//
-         .text(label) //
+      return new GLabelBuilder(Types.PROPERTY)
+         .id(toId(property))
+         .text(label)
          .build();
    }
 

--- a/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/gmodel/RelationshipEdgeFactory.java
+++ b/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/gmodel/RelationshipEdgeFactory.java
@@ -28,6 +28,7 @@ import org.eclipse.uml2.uml.Relationship;
 import com.eclipsesource.uml.glsp.model.UmlModelState;
 import com.eclipsesource.uml.glsp.util.UmlConfig.CSS;
 import com.eclipsesource.uml.glsp.util.UmlConfig.Types;
+import com.eclipsesource.uml.glsp.util.UmlIDUtil;
 import com.eclipsesource.uml.glsp.util.UmlLabelUtil;
 import com.eclipsesource.uml.modelserver.unotation.Edge;
 
@@ -40,36 +41,44 @@ public class RelationshipEdgeFactory extends AbstractGModelFactory<Relationship,
    @Override
    public GEdge create(final Relationship element) {
       if (element instanceof Association) {
-         return create((Association) element);
+         return createAssociationEdge((Association) element);
       }
       return null;
    }
 
-   protected GEdge create(final Association association) {
+   protected GEdge createAssociationEdge(final Association association) {
       EList<Property> memberEnds = association.getMemberEnds();
       Property source = memberEnds.get(0);
       String sourceId = toId(source);
       Property target = memberEnds.get(1);
       String targetId = toId(target);
 
-      GEdgeBuilder builder = new GEdgeBuilder(Types.ASSOCIATION) //
-         .id(toId(association)) //
-         .addCssClass(CSS.EDGE) //
-         .sourceId(toId(source.getType())) //
-         .targetId(toId(target.getType())) //
-         .routerKind(GConstants.RouterKind.MANHATTAN) //
-         .add(createEdgeNameLabel(source.getName(), sourceId + "_label_name", 0.1d)) //
-         .add(createEdgeMultiplicityLabel(UmlLabelUtil.getMultiplicity(source), sourceId + "_sourcelabel_multiplicity",
-            0.1d)) //
-         .add(createEdgeNameLabel(target.getName(), targetId + "_label_name", 0.9d)) //
-         .add(createEdgeMultiplicityLabel(UmlLabelUtil.getMultiplicity(target), targetId + "_targetlabel_multiplicity",
-            0.9d));
+      GEdgeBuilder builder = new GEdgeBuilder(Types.ASSOCIATION)
+         .id(toId(association))
+         .addCssClass(CSS.EDGE)
+         .sourceId(toId(source.getType()))
+         .targetId(toId(target.getType()))
+         .routerKind(GConstants.RouterKind.MANHATTAN);
+
+      GLabel sourceNameLabel = createEdgeNameLabel(source.getName(), UmlIDUtil.createLabelNameId(sourceId), 0.1d);
+      builder.add(sourceNameLabel);
+
+      GLabel sourceMultiplicityLabel = createEdgeMultiplicityLabel(UmlLabelUtil.getMultiplicity(source),
+         UmlIDUtil.createLabelMultiplicityId(sourceId), 0.1d);
+      builder.add(sourceMultiplicityLabel);
+
+      GLabel targetNameLabel = createEdgeNameLabel(target.getName(), UmlIDUtil.createLabelNameId(targetId), 0.9d);
+      builder.add(targetNameLabel);
+
+      GLabel targetMultiplicityLabel = createEdgeMultiplicityLabel(UmlLabelUtil.getMultiplicity(target),
+         UmlIDUtil.createLabelMultiplicityId(targetId), 0.9d);
+      builder.add(targetMultiplicityLabel);
 
       modelState.getIndex().getNotation(association, Edge.class).ifPresent(edge -> {
          if (edge.getBendPoints() != null) {
-            ArrayList<GPoint> gPoints = new ArrayList<>();
-            edge.getBendPoints().forEach(p -> gPoints.add(GraphUtil.copy(p)));
-            builder.addRoutingPoints(gPoints);
+            ArrayList<GPoint> bendPoints = new ArrayList<>();
+            edge.getBendPoints().forEach(p -> bendPoints.add(GraphUtil.copy(p)));
+            builder.addRoutingPoints(bendPoints);
          }
       });
       return builder.build();
@@ -85,14 +94,14 @@ public class RelationshipEdgeFactory extends AbstractGModelFactory<Relationship,
 
    protected GLabel createEdgeLabel(final String name, final double position, final String id, final String type,
       final String side) {
-      return new GLabelBuilder(type) //
-         .edgePlacement(new GEdgePlacementBuilder()//
-            .side(side)//
-            .position(position)//
-            .offset(2d) //
-            .rotate(false) //
-            .build())//
-         .id(id) //
+      return new GLabelBuilder(type)
+         .edgePlacement(new GEdgePlacementBuilder()
+            .side(side)
+            .position(position)
+            .offset(2d)
+            .rotate(false)
+            .build())
+         .id(id)
          .text(name).build();
    }
 

--- a/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/model/UmlModelIndex.java
+++ b/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/model/UmlModelIndex.java
@@ -11,7 +11,6 @@
 package com.eclipsesource.uml.glsp.model;
 
 import java.util.Optional;
-import java.util.UUID;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.util.EcoreUtil;
@@ -48,6 +47,11 @@ public class UmlModelIndex extends GModelIndexImpl {
       return super.isAdapterForType(type) || UmlModelIndex.class.equals(type);
    }
 
+   public void clear() {
+      this.semanticIndex.clear();
+      this.notationIndex.clear();
+   }
+
    public void indexSemantic(final String id, final EObject semanticElement) {
       semanticIndex.putIfAbsent(id, semanticElement);
    }
@@ -56,7 +60,7 @@ public class UmlModelIndex extends GModelIndexImpl {
       if (notationElement.getSemanticElement() != null) {
          EObject semanticElement = notationElement.getSemanticElement().getResolvedElement();
          notationIndex.put(semanticElement, notationElement);
-         semanticIndex.inverse().putIfAbsent(semanticElement, UUID.randomUUID().toString());
+         semanticIndex.inverse().putIfAbsent(semanticElement, EcoreUtil.getURI(semanticElement).fragment());
       }
 
       if (notationElement instanceof Diagram) {
@@ -124,10 +128,9 @@ public class UmlModelIndex extends GModelIndexImpl {
       } else {
          id = getSemanticId(eObject).orElse(null);
          if (id == null) {
-            id = UUID.randomUUID().toString();
+            id = EcoreUtil.getURI(eObject).fragment();
             indexSemantic(id, eObject);
          }
-
       }
       return id;
 

--- a/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/model/UmlModelState.java
+++ b/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/model/UmlModelState.java
@@ -62,8 +62,12 @@ public class UmlModelState extends GModelStateImpl {
       if (notationRoot != null && !(notationRoot instanceof Diagram)) {
          throw new GLSPServerException("Error during UML diagram loading");
       }
+      // Clear modelIndex
+      UmlModelIndex modelIndex = getIndex();
+      modelIndex.clear();
+
       // If notationRoot is null it will be initialized in UmlFacade
-      this.umlFacade = new UmlFacade((Model) semanticRoot, (Diagram) notationRoot, getIndex());
+      this.umlFacade = new UmlFacade((Model) semanticRoot, (Diagram) notationRoot, modelIndex);
    }
 
    public UmlFacade getUmlFacade() { return umlFacade; }

--- a/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/util/UmlEdgeUtil.java
+++ b/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/util/UmlEdgeUtil.java
@@ -12,16 +12,12 @@ package com.eclipsesource.uml.glsp.util;
 
 import org.eclipse.emf.ecore.EReference;
 
-public class UmlEdgeUtil {
+public final class UmlEdgeUtil {
+
+   private UmlEdgeUtil() {}
+
    public static String getStringId(final EReference reference) {
       return Integer.toString(reference.hashCode());
-   }
-
-   /**
-    * Retrieves the Edge Id, which is associated with this label.
-    */
-   public static String getEdgeId(final String labelId) {
-      return labelId.split("_")[0];
    }
 
 }

--- a/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/util/UmlIDUtil.java
+++ b/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/util/UmlIDUtil.java
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.eclipsesource.uml.glsp.util;
+
+public final class UmlIDUtil {
+
+   private UmlIDUtil() {}
+
+   public static String LABEL_NAME_SUFFIX = "_label_name";
+   public static String LABEL_MULTIIPLICITY_SUFFIX = "_label_multiplicity";
+   public static String HEADER_SUFFIX = "_header";
+   public static String HEADER_ICON_SUFFIX = "_header_icon";
+   public static String HEADER_LABEL_SUFFIX = "_header_label";
+   public static String CHILD_COMPARTMENT_SUFFIX = "_childCompartment";
+
+   public static String createLabelNameId(final String containerId) {
+      return containerId + LABEL_NAME_SUFFIX;
+   }
+
+   public static String getElementIdFromLabelName(final String labelNameId) {
+      return labelNameId.replace(LABEL_NAME_SUFFIX, "");
+   }
+
+   public static String createLabelMultiplicityId(final String containerId) {
+      return containerId + LABEL_MULTIIPLICITY_SUFFIX;
+   }
+
+   public static String getElementIdFromLabelMultiplicity(final String multiplicityLabelId) {
+      return multiplicityLabelId.replace(LABEL_MULTIIPLICITY_SUFFIX, "");
+   }
+
+   public static String createHeaderId(final String containerId) {
+      return containerId + HEADER_SUFFIX;
+   }
+
+   public static String getElementIdFromHeader(final String headerId) {
+      return headerId.replace(HEADER_SUFFIX, "");
+   }
+
+   public static String createHeaderIconId(final String containerId) {
+      return containerId + HEADER_ICON_SUFFIX;
+   }
+
+   public static String getElementIdFromHeaderIcon(final String headerIconId) {
+      return headerIconId.replace(HEADER_ICON_SUFFIX, "");
+   }
+
+   public static String createHeaderLabelId(final String containerId) {
+      return containerId + HEADER_LABEL_SUFFIX;
+   }
+
+   public static String getElementIdFromHeaderLabel(final String headerLabelId) {
+      return headerLabelId.replace(HEADER_LABEL_SUFFIX, "");
+   }
+
+   public static String createChildCompartmentId(final String containerId) {
+      return containerId + CHILD_COMPARTMENT_SUFFIX;
+   }
+
+   public static String getElementIdFromChildCompartment(final String childCompartmentId) {
+      return childCompartmentId.replace(CHILD_COMPARTMENT_SUFFIX, "");
+   }
+
+}

--- a/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/util/UmlLabelUtil.java
+++ b/server/com.eclipsesource.uml.glsp/src/main/java/com/eclipsesource/uml/glsp/util/UmlLabelUtil.java
@@ -12,7 +12,9 @@ package com.eclipsesource.uml.glsp.util;
 
 import org.eclipse.uml2.uml.Property;
 
-public class UmlLabelUtil {
+public final class UmlLabelUtil {
+
+   private UmlLabelUtil() {}
 
    public static String getTypeName(final Property property) {
       if (property.getType() != null) {


### PR DESCRIPTION
- Use UML XMI Ids as graphical element IDs instead of randomly generated UUIDs
- Introduce UmlIDUtil to stabilize graphical element ID handling
- Simplify *Factory code to enhance readability

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>