### PR TITLE
Extend UML diagram types

### DIFF
--- a/client/packages/uml-theia-integration/src/browser/command-contribution.ts
+++ b/client/packages/uml-theia-integration/src/browser/command-contribution.ts
@@ -51,24 +51,23 @@ export class UmlModelContribution implements CommandContribution, MenuContributi
                 if (this.workspaceService.tryGetRoots().length) {
                     workspaceUri = new URI(this.workspaceService.tryGetRoots()[0].uri);
 
-                    this.showInput("Name", "Name of UML Diagram", nameOfUmlModel => {
-                        this.showInput("Diagram type", "Type of UML Diagram (activity | class | package | sequence | statemachine | usecase)", diagramType => {
-                            this.createUmlDiagram(nameOfUmlModel, workspaceUri, diagramType);
-                        });
+                    this.showInput("Enter Name of UML Diagram", "Diagram name", nameOfUmlModel => {
+                        this.showInput("Enter UML Diagram Type", "activity | class | component | deployment | package | sequence | statemachine | usecase",
+                            diagramType => this.createUmlDiagram(nameOfUmlModel, workspaceUri, diagramType));
                     });
                 }
             }
         });
     }
 
-    protected showInput(hint: string, prefix: string, onEnter: (result: string) => void): void {
+    protected showInput(prefix: string, hint: string, onEnter: (result: string) => void): void {
         const quickOpenModel: QuickOpenModel = {
             onType(lookFor: string, acceptor: (items: QuickOpenItem[]) => void): void {
                 const dynamicItems: QuickOpenItem[] = [];
                 const suffix = "Press 'Enter' to confirm or 'Escape' to cancel.";
 
                 dynamicItems.push(new SingleStringInputOpenItem(
-                    `${prefix}: '${lookFor}' ${suffix}`,
+                    `${prefix}: '${lookFor}'  > ${suffix}`,
                     () => onEnter(lookFor),
                     (mode: QuickOpenMode) => mode === QuickOpenMode.OPEN,
                     () => false
@@ -98,6 +97,8 @@ export class UmlModelContribution implements CommandContribution, MenuContributi
         switch (diagramType.toLowerCase()) {
             case ("activity"): return UmlDiagramType.ACTIVITY;
             case ("class"): return UmlDiagramType.CLASS;
+            case ("component"): return UmlDiagramType.COMPONENT;
+            case ("deployment"): return UmlDiagramType.DEPLOYMENT;
             case ("package"): return UmlDiagramType.PACKAGE;
             case ("sequence"): return UmlDiagramType.SEQUENCE;
             case ("statemachine"): return UmlDiagramType.STATEMACHINE;

--- a/client/packages/uml-theia-integration/src/common/uml-model-server-client.ts
+++ b/client/packages/uml-theia-integration/src/common/uml-model-server-client.ts
@@ -14,6 +14,8 @@ export enum UmlDiagramType {
     NONE = "",
     ACTIVITY = "ACTIVITY",
     CLASS = "CLASS",
+    COMPONENT = "COMPONENT",
+    DEPLOYMENT = "DEPLOYMENT",
     PACKAGE = "PACKAGE",
     SEQUENCE = "SEQUENCE",
     STATEMACHINE = "STATEMACHINE",

--- a/server/com.eclipsesource.uml.modelserver/META-INF/MANIFEST.MF
+++ b/server/com.eclipsesource.uml.modelserver/META-INF/MANIFEST.MF
@@ -32,4 +32,6 @@ Require-Bundle: org.apache.log4j;bundle-version="[1.2.15,2.0.0)",
 Bundle-ActivationPolicy: lazy
 Export-Package: com.eclipsesource.uml.modelserver,
  com.eclipsesource.uml.modelserver.commands.contributions,
- com.eclipsesource.uml.modelserver.unotation
+ com.eclipsesource.uml.modelserver.unotation,
+ com.eclipsesource.uml.modelserver.unotation.impl,
+ com.eclipsesource.uml.modelserver.unotation.util

--- a/server/com.eclipsesource.uml.modelserver/resources/unotation.ecore
+++ b/server/com.eclipsesource.uml.modelserver/resources/unotation.ecore
@@ -38,5 +38,7 @@
     <eLiterals name="SEQUENCE" value="3"/>
     <eLiterals name="STATEMACHINE" value="4"/>
     <eLiterals name="USECASE" value="5"/>
+    <eLiterals name="DEPLOYMENT" value="6"/>
+    <eLiterals name="COMPONENT" value="7"/>
   </eClassifiers>
 </ecore:EPackage>

--- a/server/com.eclipsesource.uml.modelserver/resources/unotation.genmodel
+++ b/server/com.eclipsesource.uml.modelserver/resources/unotation.genmodel
@@ -19,6 +19,8 @@
       <genEnumLiterals ecoreEnumLiteral="unotation.ecore#//Representation/SEQUENCE"/>
       <genEnumLiterals ecoreEnumLiteral="unotation.ecore#//Representation/STATEMACHINE"/>
       <genEnumLiterals ecoreEnumLiteral="unotation.ecore#//Representation/USECASE"/>
+      <genEnumLiterals ecoreEnumLiteral="unotation.ecore#//Representation/DEPLOYMENT"/>
+      <genEnumLiterals ecoreEnumLiteral="unotation.ecore#//Representation/COMPONENT"/>
     </genEnums>
     <genClasses ecoreClass="unotation.ecore#//Shape">
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference unotation.ecore#//Shape/position"/>

--- a/server/com.eclipsesource.uml.modelserver/src/main/java-gen/com/eclipsesource/uml/modelserver/unotation/Representation.java
+++ b/server/com.eclipsesource.uml.modelserver/src/main/java-gen/com/eclipsesource/uml/modelserver/unotation/Representation.java
@@ -84,7 +84,23 @@ public enum Representation implements Enumerator {
     * @generated
     * @ordered
     */
-   USECASE(5, "USECASE", "USECASE");
+   USECASE(5, "USECASE", "USECASE"), /**
+    * The '<em><b>DEPLOYMENT</b></em>' literal object.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #DEPLOYMENT_VALUE
+    * @generated
+    * @ordered
+    */
+   DEPLOYMENT(6, "DEPLOYMENT", "DEPLOYMENT"), /**
+    * The '<em><b>COMPONENT</b></em>' literal object.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #COMPONENT_VALUE
+    * @generated
+    * @ordered
+    */
+   COMPONENT(7, "COMPONENT", "COMPONENT");
 
    /**
     * The '<em><b>ACTIVITY</b></em>' literal value.
@@ -153,6 +169,28 @@ public enum Representation implements Enumerator {
    public static final int USECASE_VALUE = 5;
 
    /**
+    * The '<em><b>DEPLOYMENT</b></em>' literal value.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #DEPLOYMENT
+    * @model
+    * @generated
+    * @ordered
+    */
+   public static final int DEPLOYMENT_VALUE = 6;
+
+   /**
+    * The '<em><b>COMPONENT</b></em>' literal value.
+    * <!-- begin-user-doc -->
+    * <!-- end-user-doc -->
+    * @see #COMPONENT
+    * @model
+    * @generated
+    * @ordered
+    */
+   public static final int COMPONENT_VALUE = 7;
+
+   /**
     * An array of all the '<em><b>Representation</b></em>' enumerators.
     * <!-- begin-user-doc -->
     * <!-- end-user-doc -->
@@ -166,6 +204,8 @@ public enum Representation implements Enumerator {
          SEQUENCE,
          STATEMACHINE,
          USECASE,
+         DEPLOYMENT,
+         COMPONENT,
       };
 
    /**
@@ -228,6 +268,8 @@ public enum Representation implements Enumerator {
          case SEQUENCE_VALUE: return SEQUENCE;
          case STATEMACHINE_VALUE: return STATEMACHINE;
          case USECASE_VALUE: return USECASE;
+         case DEPLOYMENT_VALUE: return DEPLOYMENT;
+         case COMPONENT_VALUE: return COMPONENT;
       }
       return null;
    }

--- a/server/com.eclipsesource.uml.modelserver/src/main/java-gen/com/eclipsesource/uml/modelserver/unotation/impl/UnotationPackageImpl.java
+++ b/server/com.eclipsesource.uml.modelserver/src/main/java-gen/com/eclipsesource/uml/modelserver/unotation/impl/UnotationPackageImpl.java
@@ -431,6 +431,8 @@ public class UnotationPackageImpl extends EPackageImpl implements UnotationPacka
       addEEnumLiteral(representationEEnum, Representation.SEQUENCE);
       addEEnumLiteral(representationEEnum, Representation.STATEMACHINE);
       addEEnumLiteral(representationEEnum, Representation.USECASE);
+      addEEnumLiteral(representationEEnum, Representation.DEPLOYMENT);
+      addEEnumLiteral(representationEEnum, Representation.COMPONENT);
 
       // Create resource
       createResource(eNS_URI);

--- a/server/com.eclipsesource.uml.modelserver/src/main/java/com/eclipsesource/uml/modelserver/UmlNotationUtil.java
+++ b/server/com.eclipsesource.uml.modelserver/src/main/java/com/eclipsesource/uml/modelserver/UmlNotationUtil.java
@@ -24,6 +24,10 @@ public final class UmlNotationUtil {
             return Representation.ACTIVITY;
          case "class":
             return Representation.CLASS;
+         case "component":
+            return Representation.COMPONENT;
+         case "deployment":
+            return Representation.DEPLOYMENT;
          case "package":
             return Representation.PACKAGE;
          case "sequence":


### PR DESCRIPTION
- Extends Unotation model by Representation types COMPONENT and DEPLOYMENT
- Adapt client interface to allow new types

Signed-off-by: Nina Doschek <ndoschek@eclipsesource.com>